### PR TITLE
stainless bug (they're fixing)

### DIFF
--- a/browserf.go
+++ b/browserf.go
@@ -193,7 +193,7 @@ func (r *BrowserFService) WriteFile(ctx context.Context, id string, contents io.
 		return
 	}
 	path := fmt.Sprintf("browsers/%s/fs/write_file", id)
-	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPut, path, nil, nil, opts...)
+	err = requestconfig.ExecuteNewRequest(ctx, http.MethodPut, path, body, nil, opts...)
 	return
 }
 


### PR DESCRIPTION
have a thread going with stainless support where they're aware that this is a bug. Until they fix it, going to patch it

---

<!-- mesa-description-start -->
## TL;DR
Patched an upstream bug in the `stainless` dependency that was causing issues with file writing.

## Why we made these changes
This is a temporary workaround for a known bug in `stainless`. We're in contact with their support team, who have acknowledged the issue and are working on a fix. This change will be reverted once the upstream dependency is patched.

## What changed?
- Implemented a temporary patch in our file writing logic to avoid the bug.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/onkernel/settings/pull-requests)_</sup>
<!-- mesa-description-end -->