### PR TITLE
ci: add Semgrep SAST scanning on pull requests

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,17 @@
+name: Semgrep
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  scan:
+    uses: kernel/security-workflows/.github/workflows/semgrep.yml@main
+    with:
+      extra-configs: '--config p/golang --config p/trailofbits'
+      codebase-description: 'Stainless-generated Go SDK for the Kernel API (public Go module used by customers)'
+    secrets: inherit


### PR DESCRIPTION
## Summary

Follow-up from the INC-51 postmortem ([KERNEL-1191](https://linear.app/onkernel/issue/KERNEL-1191/finalize-scope-of-repos-under-elevated-vulnerability-management)): the Kernel MCP vulnerability was missed in part because the MCP repo was not subscribed to the shared Semgrep workflow. Expanding the scope to the customer-facing SDKs so the same gap can't happen there.

This PR adds `.github/workflows/semgrep.yml` that calls the reusable workflow in [kernel/security-workflows](https://github.com/kernel/security-workflows). Runs on every PR targeting \`main\` with the agent-powered triage flow already used in \`kernel\`, \`kernel-images\`, \`cli\`, \`kernel-mcp-server\`, etc.

Semgrep configs: \`p/golang\`, \`p/trailofbits\`.

Uses org-level secrets already provisioned for existing subscribers (\`CURSOR_API_KEY\`, \`CURSOR_PREFERRED_MODEL\`, \`ADMIN_APP_ID\`, \`ADMIN_APP_PRIVATE_KEY\`, \`SOCKET_API_TOKEN\`) via \`secrets: inherit\`.

### Stainless caveat

This SDK is Stainless-generated. Stainless doesn't appear to manage arbitrary files under \`.github/workflows/\`, but if the next regeneration wipes this file, we'll need to either add it to the Stainless config or restore it via a post-generation step.

## Test plan

- [ ] CI runs on this PR itself (first scan of the repo). Verify the \`Semgrep / scan\` check appears and completes.
- [ ] If findings are produced, confirm the triage agent posts comments as expected.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a CI workflow that runs Semgrep via a reusable workflow; low code risk but may affect PR CI duration/failures due to new security findings or workflow configuration.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/semgrep.yml`) that runs Semgrep on every pull request to `main` by invoking the shared `kernel/security-workflows` reusable workflow.
> 
> The scan is configured with the `p/golang` and `p/trailofbits` rulesets, grants `pull-requests: write` to allow PR feedback, and inherits org secrets for the scan/triage flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c89089fef6fcaab7ba221a6653bb92afb916c649. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->