### PR TITLE
fix: suppress Go transport headers in raw browser curl

### DIFF
--- a/lib/browserrouting/rawcurl.go
+++ b/lib/browserrouting/rawcurl.go
@@ -23,14 +23,23 @@ func NewHTTPClient(browserBaseURL, jwt string, underlying *http.Client) *http.Cl
 	if underlying == nil {
 		underlying = http.DefaultClient
 	}
-	rt := underlying.Transport
+	rt := rawCURLUnderlyingTransport(underlying.Transport)
 	if rt == nil {
-		rt = http.DefaultTransport
+		rt = rawCURLUnderlyingTransport(http.DefaultTransport)
 	}
 	return &http.Client{
 		Transport: newRawCURLRoundTripper(browserBaseURL, jwt, rt),
 		Timeout:   underlying.Timeout,
 	}
+}
+
+func rawCURLUnderlyingTransport(rt http.RoundTripper) http.RoundTripper {
+	if transport, ok := rt.(*http.Transport); ok {
+		clone := transport.Clone()
+		clone.DisableCompression = true
+		return clone
+	}
+	return rt
 }
 
 // newRawCURLRoundTripper returns an [http.RoundTripper] that maps each request
@@ -76,6 +85,18 @@ func (t *RawCURLRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	out.URL = proxyURL
 	out.Host = proxyURL.Host
 	out.RequestURI = ""
+	if !hasHeader(out.Header, "User-Agent") {
+		out.Header["User-Agent"] = nil
+	}
 
 	return t.underlying.RoundTrip(out)
+}
+
+func hasHeader(headers http.Header, name string) bool {
+	for key := range headers {
+		if strings.EqualFold(key, name) {
+			return true
+		}
+	}
+	return false
 }

--- a/lib/browserrouting/rawcurl_test.go
+++ b/lib/browserrouting/rawcurl_test.go
@@ -44,6 +44,64 @@ func TestRawCURLRoundTripper(t *testing.T) {
 	}
 }
 
+func TestRawCURLRoundTripperSuppressesGoTransportHeaders(t *testing.T) {
+	var sawUserAgent, sawAcceptEncoding string
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawUserAgent = r.Header.Get("User-Agent")
+		sawAcceptEncoding = r.Header.Get("Accept-Encoding")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer up.Close()
+
+	client := NewHTTPClient(up.URL+"/browser/kernel", "jwt1", http.DefaultClient)
+	req, err := http.NewRequest(http.MethodGet, "https://example.org/foo", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+
+	if sawUserAgent != "" {
+		t.Fatalf("unexpected user-agent: %q", sawUserAgent)
+	}
+	if sawAcceptEncoding != "" {
+		t.Fatalf("unexpected accept-encoding: %q", sawAcceptEncoding)
+	}
+}
+
+func TestRawCURLRoundTripperPreservesExplicitTransportHeaders(t *testing.T) {
+	var sawUserAgent, sawAcceptEncoding string
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawUserAgent = r.Header.Get("User-Agent")
+		sawAcceptEncoding = r.Header.Get("Accept-Encoding")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer up.Close()
+
+	client := NewHTTPClient(up.URL+"/browser/kernel", "jwt1", http.DefaultClient)
+	req, err := http.NewRequest(http.MethodGet, "https://example.org/foo", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("User-Agent", "custom-agent")
+	req.Header.Set("Accept-Encoding", "identity")
+	res, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+
+	if sawUserAgent != "custom-agent" {
+		t.Fatalf("user-agent: %q", sawUserAgent)
+	}
+	if sawAcceptEncoding != "identity" {
+		t.Fatalf("accept-encoding: %q", sawAcceptEncoding)
+	}
+}
+
 func TestRawCURLRoundTripperRelativeURL(t *testing.T) {
 	rt := newRawCURLRoundTripper("https://x/browser/kernel", "j", http.DefaultTransport)
 	req, _ := http.NewRequest(http.MethodGet, "/relative", nil)


### PR DESCRIPTION
## Summary

- prevent Go's implicit `User-Agent: Go-http-client/1.1` from reaching `/curl/raw` when callers did not explicitly set a user agent
- disable Go transport compression on the raw-curl leg so implicit `Accept-Encoding: gzip` is not forwarded into Chromium
- preserve explicit caller-provided `User-Agent` and `Accept-Encoding` headers

## Test plan

- `go test ./lib/browserrouting ./...`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to HTTP transport/header behavior with targeted tests; main risk is subtle header/encoding behavior differences for callers relying on Go defaults.
> 
> **Overview**
> Raw `/curl/raw` browser-egress requests no longer leak Go client defaults: `NewHTTPClient` now clones `*http.Transport` with compression disabled (avoiding implicit `Accept-Encoding: gzip`), and `RoundTrip` explicitly suppresses Go’s default `User-Agent` when the caller didn’t set one.
> 
> Adds tests verifying that implicit `User-Agent`/`Accept-Encoding` are removed while explicitly provided values are preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 401aa3881e880a058946f2eae5d9772c227a911d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->