### PR TITLE
ci: add centralized vuln remediation workflow

### DIFF
--- a/.github/workflows/vuln-remediation.yml
+++ b/.github/workflows/vuln-remediation.yml
@@ -1,0 +1,17 @@
+name: Vulnerability Remediation
+
+on:
+  schedule:
+    - cron: '0 3 * * 3'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  remediate:
+    uses: kernel/security-workflows/.github/workflows/vuln-remediation.yml@main
+    with:
+      go-version-file: 'go.mod'
+    secrets: inherit

--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,1 @@
+version: 2


### PR DESCRIPTION
Thin caller to the reusable 3-stage pipeline (triage → fix → PR) in kernel/security-workflows.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Grants a workflow `contents` and `pull-requests` write access and runs on a schedule, which could create automated dependency-change PRs if misconfigured.
> 
> **Overview**
> Introduces a new `Vulnerability Remediation` GitHub Actions workflow that runs weekly (and manually) and delegates to `kernel/security-workflows/.github/workflows/vuln-remediation.yml`, passing the repo’s `go.mod` for Go version resolution and inheriting secrets.
> 
> Adds a minimal `socket.yml` (`version: 2`) configuration file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4ab24443bde5961a86c9da085335420f88bbd46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->