### PR TITLE
ci: use org variable for CURSOR_PREFERRED_MODEL

### DIFF
--- a/.github/workflows/update-cli-coverage.yml
+++ b/.github/workflows/update-cli-coverage.yml
@@ -411,4 +411,4 @@ jobs:
           - Streaming methods may have different CLI implementations (e.g., follow flags)
           - Even if no coverage gaps are found, still create a PR for the SDK version bump
           - Ensure code compiles before pushing
-          " --model ${{ secrets.CURSOR_PREFERRED_MODEL }} --force --output-format=text
+          " --model ${{ vars.CURSOR_PREFERRED_MODEL }} --force --output-format=text


### PR DESCRIPTION
Switches `agent --model ${{ secrets.CURSOR_PREFERRED_MODEL }}` to `${{ vars.CURSOR_PREFERRED_MODEL }}` so the model value is visible in plaintext.

The org-wide variable `CURSOR_PREFERRED_MODEL` has been set to `claude-opus-4-8-thinking-max`.

Part of an org-wide migration of this key from secret to variable. The secret will be deleted once all repos are migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI config change for model selection; no application or security-sensitive runtime logic.
> 
> **Overview**
> The **update-cli-coverage** workflow now passes the Cursor agent model via the org/repository variable **`vars.CURSOR_PREFERRED_MODEL`** instead of **`secrets.CURSOR_PREFERRED_MODEL`** on the `cursor-agent` `--model` flag.
> 
> This aligns with an org-wide move to store the preferred model name as a variable (plaintext, easier to audit/update) rather than a secret, without changing workflow behavior beyond where the value is read from.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07b04237d3428832c4da0b85f06384de37103dd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->