### PR TITLE
ci: enable Cursor Max Mode for cursor-agent workflow

### DIFF
--- a/.github/workflows/update-cli-coverage.yml
+++ b/.github/workflows/update-cli-coverage.yml
@@ -77,6 +77,13 @@ jobs:
           curl https://cursor.com/install -fsS | bash
           echo "$HOME/.cursor/bin" >> $GITHUB_PATH
 
+      - name: Enable Cursor Max Mode
+        run: |
+          CFG_DIR="$HOME/.cursor"
+          mkdir -p "$CFG_DIR"
+          echo '{"maxMode": true}' > "$CFG_DIR/cli-config.json"
+          echo "CURSOR_CONFIG_DIR=$CFG_DIR" >> "$GITHUB_ENV"
+
       - name: Configure git identity
         run: |
           git config --global user.name "kernel-internal[bot]"


### PR DESCRIPTION
## Problem
The `update-cli-coverage.yml` workflow runs `cursor-agent` with `--model ${{ vars.CURSOR_PREFERRED_MODEL }}` (currently `claude-opus-4-8-xhigh`). That model requires Cursor **Max Mode**, so CI fails with `Max Mode Required`.

A fresh `cursor-agent` install defaults to `maxMode=false`, and it must be explicitly enabled via `cli-config.json`.

## Fix
Add an "Enable Cursor Max Mode" step immediately after the Cursor CLI install step and before the agent invocation:

- Writes `{"maxMode": true}` to `cli-config.json`.
- Pins `CURSOR_CONFIG_DIR` and propagates it via `$GITHUB_ENV`. GitHub-hosted runners set `XDG_CONFIG_HOME=/home/runner/.config`, and cursor-agent resolves its config dir as `CURSOR_CONFIG_DIR || $XDG_CONFIG_HOME/cursor || ~/.cursor`. Without pinning `CURSOR_CONFIG_DIR`, a `~/.cursor/cli-config.json` write would be ignored.

This mirrors the proven fix already applied in `kernel/kernel`.

## Requirements
The `CURSOR_API_KEY` secret used by the workflow must be Max-Mode-entitled for this to take effect.

## Note
This repo is auto-generated by Stainless; only the workflow YAML was modified.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change; no application or runtime behavior beyond fixing CI agent configuration.
> 
> **Overview**
> Fixes **`update-cli-coverage`** CI failures when `cursor-agent` runs with a model that requires **Max Mode** (e.g. `claude-opus-4-8-xhigh` via `CURSOR_PREFERRED_MODEL`), which errors with `Max Mode Required` on a fresh install.
> 
> Adds an **Enable Cursor Max Mode** step right after installing the Cursor CLI: writes `{"maxMode": true}` to `cli-config.json` under `$HOME/.cursor` and sets **`CURSOR_CONFIG_DIR`** in `$GITHUB_ENV` so `cursor-agent` picks up that config instead of ignoring it when runners use `XDG_CONFIG_HOME`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97261711b9d87a19bac5cbb67ef9b029256d287b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->