### PR TITLE
feat: add complete audit log download helper

### DIFF
--- a/auditlog_download.go
+++ b/auditlog_download.go
@@ -16,6 +16,7 @@ import (
 )
 
 const (
+	auditLogDownloadMaxChunkRows       = 50_000
 	auditLogDownloadMaxTransferRetries = 6
 	auditLogDownloadMaxRetryDelay      = 8 * time.Second
 	auditLogDownloadRetryBaseDelay     = time.Second
@@ -159,7 +160,7 @@ func (r *AuditLogService) downloadAuditLogChunk(ctx context.Context, query Audit
 		if err == nil || attempt > maxTransferRetries || !errors.As(err, &transferErr) {
 			return body, header, err
 		}
-		delay := min(auditLogDownloadRetryBaseDelay<<(attempt-1), auditLogDownloadMaxRetryDelay)
+		delay := auditLogDownloadRetryDelay(attempt)
 		select {
 		case <-ctx.Done():
 			return nil, nil, ctx.Err()
@@ -202,13 +203,31 @@ func (e *auditLogTransferError) Unwrap() error {
 	return e.err
 }
 
+func auditLogDownloadRetryDelay(attempt int) time.Duration {
+	delay := auditLogDownloadRetryBaseDelay
+	for retry := 1; retry < attempt && delay < auditLogDownloadMaxRetryDelay; retry++ {
+		delay *= 2
+	}
+	return min(delay, auditLogDownloadMaxRetryDelay)
+}
+
 func parseAuditLogDownloadHeaders(header http.Header, currentCursor string) (int64, string, bool, error) {
-	hasMore, err := strconv.ParseBool(header.Get("X-Has-More"))
-	if err != nil {
+	var hasMore bool
+	switch header.Get("X-Has-More") {
+	case "true":
+		hasMore = true
+	case "false":
+		hasMore = false
+	default:
 		return 0, "", false, fmt.Errorf("response missing or invalid X-Has-More header")
 	}
-	rows, err := strconv.ParseInt(header.Get("X-Row-Count"), 10, 64)
-	if err != nil || rows < 0 {
+
+	rowCount := header.Get("X-Row-Count")
+	if !isAuditLogDownloadDecimal(rowCount) {
+		return 0, "", false, fmt.Errorf("response missing or invalid X-Row-Count header")
+	}
+	rows, err := strconv.ParseInt(rowCount, 10, 64)
+	if err != nil || rows > auditLogDownloadMaxChunkRows {
 		return 0, "", false, fmt.Errorf("response missing or invalid X-Row-Count header")
 	}
 	nextCursor := header.Get("X-Next-Cursor")
@@ -219,6 +238,18 @@ func parseAuditLogDownloadHeaders(header http.Header, currentCursor string) (int
 		return 0, "", false, fmt.Errorf("response returned a cursor after the final chunk")
 	}
 	return rows, nextCursor, hasMore, nil
+}
+
+func isAuditLogDownloadDecimal(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, char := range value {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func writeAuditLogChunk(dst io.Writer, body []byte) error {

--- a/auditlog_download.go
+++ b/auditlog_download.go
@@ -1,0 +1,215 @@
+package kernel
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/kernel/kernel-go-sdk/option"
+	"github.com/kernel/kernel-go-sdk/packages/param"
+)
+
+const (
+	auditLogDownloadAttempts      = 7
+	auditLogDownloadMaxRetryDelay = 8 * time.Second
+)
+
+var auditLogDownloadRetryBaseDelay = time.Second
+
+// AuditLogDownloadParams configures a complete audit log export.
+type AuditLogDownloadParams struct {
+	End           time.Time
+	Start         time.Time
+	AuthStrategy  param.Opt[string]
+	Limit         param.Opt[int64]
+	Method        param.Opt[string]
+	Search        param.Opt[string]
+	Service       param.Opt[string]
+	ExcludeMethod []string
+	Format        AuditLogExportChunkParamsFormat
+	SearchUserID  []string
+}
+
+// AuditLogDownloadResult summarizes a completed audit log download.
+type AuditLogDownloadResult struct {
+	BytesWritten int64
+	Chunks       int
+	Rows         int64
+}
+
+// AuditLogDownloadProgress reports progress after a verified chunk is written.
+type AuditLogDownloadProgress struct {
+	AuditLogDownloadResult
+	ChunkRows int64
+}
+
+// AuditLogDownloadOption configures an audit log download.
+type AuditLogDownloadOption func(*auditLogDownloadConfig)
+
+type auditLogDownloadConfig struct {
+	onProgress     func(AuditLogDownloadProgress)
+	requestOptions []option.RequestOption
+}
+
+// WithAuditLogDownloadProgress registers a callback that runs after each chunk
+// is verified and written.
+func WithAuditLogDownloadProgress(fn func(AuditLogDownloadProgress)) AuditLogDownloadOption {
+	return func(config *auditLogDownloadConfig) {
+		config.onProgress = fn
+	}
+}
+
+// WithAuditLogDownloadRequestOptions applies request options to every chunk
+// request. Download controls retries itself so it can also retry truncated or
+// corrupt response bodies.
+func WithAuditLogDownloadRequestOptions(opts ...option.RequestOption) AuditLogDownloadOption {
+	return func(config *auditLogDownloadConfig) {
+		config.requestOptions = append(config.requestOptions, opts...)
+	}
+}
+
+// Download writes a complete audit log export to dst. It requests chunks until
+// the export is complete, verifies every chunk checksum, and retries transient
+// transfer failures. Download does not close dst.
+func (r *AuditLogService) Download(ctx context.Context, params AuditLogDownloadParams, dst io.Writer, opts ...AuditLogDownloadOption) (AuditLogDownloadResult, error) {
+	if dst == nil {
+		return AuditLogDownloadResult{}, fmt.Errorf("audit log download destination is nil")
+	}
+
+	config := auditLogDownloadConfig{}
+	for _, opt := range opts {
+		opt(&config)
+	}
+
+	query := AuditLogExportChunkParams{
+		End:           params.End,
+		Start:         params.Start,
+		AuthStrategy:  params.AuthStrategy,
+		Limit:         params.Limit,
+		Method:        params.Method,
+		Search:        params.Search,
+		Service:       params.Service,
+		ExcludeMethod: params.ExcludeMethod,
+		Format:        params.Format,
+		SearchUserID:  params.SearchUserID,
+	}
+	cursor := ""
+	result := AuditLogDownloadResult{}
+	for {
+		if cursor != "" {
+			query.Cursor = String(cursor)
+		}
+		body, header, err := r.downloadAuditLogChunk(ctx, query, config.requestOptions)
+		if err != nil {
+			return result, err
+		}
+		chunkRows, nextCursor, hasMore, err := parseAuditLogDownloadHeaders(header, cursor)
+		if err != nil {
+			return result, err
+		}
+		if err := writeAuditLogChunk(dst, body); err != nil {
+			return result, fmt.Errorf("write audit log download: %w", err)
+		}
+
+		cursor = nextCursor
+		result.BytesWritten += int64(len(body))
+		result.Chunks++
+		result.Rows += chunkRows
+		if config.onProgress != nil {
+			config.onProgress(AuditLogDownloadProgress{
+				AuditLogDownloadResult: result,
+				ChunkRows:              chunkRows,
+			})
+		}
+		if !hasMore {
+			return result, nil
+		}
+	}
+}
+
+func (r *AuditLogService) downloadAuditLogChunk(ctx context.Context, query AuditLogExportChunkParams, opts []option.RequestOption) ([]byte, http.Header, error) {
+	for attempt := 1; ; attempt++ {
+		body, header, err := r.downloadAuditLogChunkOnce(ctx, query, opts)
+		if err == nil || attempt == auditLogDownloadAttempts || !retryableAuditLogDownloadError(err) {
+			return body, header, err
+		}
+		delay := min(auditLogDownloadRetryBaseDelay<<(attempt-1), auditLogDownloadMaxRetryDelay)
+		select {
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+}
+
+func (r *AuditLogService) downloadAuditLogChunkOnce(ctx context.Context, query AuditLogExportChunkParams, opts []option.RequestOption) ([]byte, http.Header, error) {
+	requestOpts := make([]option.RequestOption, 0, len(opts)+1)
+	requestOpts = append(requestOpts, opts...)
+	requestOpts = append(requestOpts, option.WithMaxRetries(0))
+	res, err := r.ExportChunk(ctx, query, requestOpts...)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read audit log chunk: %w", err)
+	}
+	want := res.Header.Get("X-Content-Sha256")
+	if want == "" {
+		return nil, nil, fmt.Errorf("response missing X-Content-Sha256 header")
+	}
+	sum := sha256.Sum256(body)
+	if got := hex.EncodeToString(sum[:]); got != want {
+		return nil, nil, fmt.Errorf("audit log chunk checksum mismatch (got %s, want %s)", got, want)
+	}
+	return body, res.Header, nil
+}
+
+func retryableAuditLogDownloadError(err error) bool {
+	var apiErr *Error
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode == http.StatusTooManyRequests || apiErr.StatusCode >= 500
+	}
+	return !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded)
+}
+
+func parseAuditLogDownloadHeaders(header http.Header, currentCursor string) (int64, string, bool, error) {
+	hasMore, err := strconv.ParseBool(header.Get("X-Has-More"))
+	if err != nil {
+		return 0, "", false, fmt.Errorf("response missing or invalid X-Has-More header")
+	}
+	rows, err := strconv.ParseInt(header.Get("X-Row-Count"), 10, 64)
+	if err != nil || rows < 0 {
+		return 0, "", false, fmt.Errorf("response missing or invalid X-Row-Count header")
+	}
+	nextCursor := header.Get("X-Next-Cursor")
+	if hasMore && (nextCursor == "" || nextCursor == currentCursor) {
+		return 0, "", false, fmt.Errorf("response has invalid X-Next-Cursor header")
+	}
+	if !hasMore && nextCursor != "" {
+		return 0, "", false, fmt.Errorf("response returned a cursor after the final chunk")
+	}
+	return rows, nextCursor, hasMore, nil
+}
+
+func writeAuditLogChunk(dst io.Writer, body []byte) error {
+	for len(body) > 0 {
+		n, err := dst.Write(body)
+		if err != nil {
+			return err
+		}
+		if n <= 0 || n > len(body) {
+			return io.ErrShortWrite
+		}
+		body = body[n:]
+	}
+	return nil
+}

--- a/auditlog_download.go
+++ b/auditlog_download.go
@@ -32,7 +32,6 @@ type AuditLogDownloadParams struct {
 	Search        param.Opt[string]
 	Service       param.Opt[string]
 	ExcludeMethod []string
-	Format        AuditLogExportChunkParamsFormat
 	SearchUserID  []string
 }
 
@@ -85,11 +84,12 @@ func WithAuditLogDownloadMaxTransferRetries(retries int) AuditLogDownloadOption 
 	}
 }
 
-// Download writes a complete audit log export to dst. It requests chunks until
-// the export is complete, verifies every chunk checksum, and retries transient
-// transfer failures. Download does not close dst. If Download returns an error,
-// dst may contain a partial export; use a temporary file and atomic rename when
-// the completed export must be published atomically.
+// Download writes a complete gzip-compressed JSON Lines audit log export to
+// dst. It requests chunks until the export is complete, verifies every chunk
+// checksum, and retries transient transfer failures. Download does not close
+// dst. If Download returns an error, dst may contain a partial export; use a
+// temporary file and atomic rename when the completed export must be published
+// atomically.
 func (r *AuditLogService) Download(ctx context.Context, params AuditLogDownloadParams, dst io.Writer, opts ...AuditLogDownloadOption) (AuditLogDownloadResult, error) {
 	if dst == nil {
 		return AuditLogDownloadResult{}, fmt.Errorf("audit log download destination is nil")
@@ -109,7 +109,6 @@ func (r *AuditLogService) Download(ctx context.Context, params AuditLogDownloadP
 		Search:        params.Search,
 		Service:       params.Service,
 		ExcludeMethod: params.ExcludeMethod,
-		Format:        params.Format,
 		SearchUserID:  params.SearchUserID,
 	}
 	cursor := ""

--- a/auditlog_download.go
+++ b/auditlog_download.go
@@ -16,11 +16,10 @@ import (
 )
 
 const (
-	auditLogDownloadAttempts      = 7
-	auditLogDownloadMaxRetryDelay = 8 * time.Second
+	auditLogDownloadMaxTransferRetries = 6
+	auditLogDownloadMaxRetryDelay      = 8 * time.Second
+	auditLogDownloadRetryBaseDelay     = time.Second
 )
-
-var auditLogDownloadRetryBaseDelay = time.Second
 
 // AuditLogDownloadParams configures a complete audit log export.
 type AuditLogDownloadParams struct {
@@ -53,8 +52,9 @@ type AuditLogDownloadProgress struct {
 type AuditLogDownloadOption func(*auditLogDownloadConfig)
 
 type auditLogDownloadConfig struct {
-	onProgress     func(AuditLogDownloadProgress)
-	requestOptions []option.RequestOption
+	onProgress         func(AuditLogDownloadProgress)
+	requestOptions     []option.RequestOption
+	maxTransferRetries int
 }
 
 // WithAuditLogDownloadProgress registers a callback that runs after each chunk
@@ -65,24 +65,36 @@ func WithAuditLogDownloadProgress(fn func(AuditLogDownloadProgress)) AuditLogDow
 	}
 }
 
-// WithAuditLogDownloadRequestOptions applies request options to every chunk
-// request. Download controls retries itself so it can also retry truncated or
-// corrupt response bodies.
+// WithAuditLogDownloadRequestOptions applies request options, including the
+// standard HTTP retry policy, to every chunk request.
 func WithAuditLogDownloadRequestOptions(opts ...option.RequestOption) AuditLogDownloadOption {
 	return func(config *auditLogDownloadConfig) {
 		config.requestOptions = append(config.requestOptions, opts...)
 	}
 }
 
+// WithAuditLogDownloadMaxTransferRetries sets the number of retries for body
+// read and checksum failures. HTTP retries remain controlled by request options.
+func WithAuditLogDownloadMaxTransferRetries(retries int) AuditLogDownloadOption {
+	if retries < 0 {
+		panic("kernel: audit log download cannot have fewer than 0 transfer retries")
+	}
+	return func(config *auditLogDownloadConfig) {
+		config.maxTransferRetries = retries
+	}
+}
+
 // Download writes a complete audit log export to dst. It requests chunks until
 // the export is complete, verifies every chunk checksum, and retries transient
-// transfer failures. Download does not close dst.
+// transfer failures. Download does not close dst. If Download returns an error,
+// dst may contain a partial export; use a temporary file and atomic rename when
+// the completed export must be published atomically.
 func (r *AuditLogService) Download(ctx context.Context, params AuditLogDownloadParams, dst io.Writer, opts ...AuditLogDownloadOption) (AuditLogDownloadResult, error) {
 	if dst == nil {
 		return AuditLogDownloadResult{}, fmt.Errorf("audit log download destination is nil")
 	}
 
-	config := auditLogDownloadConfig{}
+	config := auditLogDownloadConfig{maxTransferRetries: auditLogDownloadMaxTransferRetries}
 	for _, opt := range opts {
 		opt(&config)
 	}
@@ -101,17 +113,24 @@ func (r *AuditLogService) Download(ctx context.Context, params AuditLogDownloadP
 	}
 	cursor := ""
 	result := AuditLogDownloadResult{}
+	seenCursors := make(map[string]struct{})
 	for {
 		if cursor != "" {
 			query.Cursor = String(cursor)
 		}
-		body, header, err := r.downloadAuditLogChunk(ctx, query, config.requestOptions)
+		body, header, err := r.downloadAuditLogChunk(ctx, query, config.requestOptions, config.maxTransferRetries)
 		if err != nil {
 			return result, err
 		}
 		chunkRows, nextCursor, hasMore, err := parseAuditLogDownloadHeaders(header, cursor)
 		if err != nil {
 			return result, err
+		}
+		if hasMore {
+			if _, ok := seenCursors[nextCursor]; ok {
+				return result, fmt.Errorf("response repeated X-Next-Cursor header")
+			}
+			seenCursors[nextCursor] = struct{}{}
 		}
 		if err := writeAuditLogChunk(dst, body); err != nil {
 			return result, fmt.Errorf("write audit log download: %w", err)
@@ -133,10 +152,11 @@ func (r *AuditLogService) Download(ctx context.Context, params AuditLogDownloadP
 	}
 }
 
-func (r *AuditLogService) downloadAuditLogChunk(ctx context.Context, query AuditLogExportChunkParams, opts []option.RequestOption) ([]byte, http.Header, error) {
+func (r *AuditLogService) downloadAuditLogChunk(ctx context.Context, query AuditLogExportChunkParams, opts []option.RequestOption, maxTransferRetries int) ([]byte, http.Header, error) {
 	for attempt := 1; ; attempt++ {
 		body, header, err := r.downloadAuditLogChunkOnce(ctx, query, opts)
-		if err == nil || attempt == auditLogDownloadAttempts || !retryableAuditLogDownloadError(err) {
+		var transferErr *auditLogTransferError
+		if err == nil || attempt > maxTransferRetries || !errors.As(err, &transferErr) {
 			return body, header, err
 		}
 		delay := min(auditLogDownloadRetryBaseDelay<<(attempt-1), auditLogDownloadMaxRetryDelay)
@@ -149,10 +169,7 @@ func (r *AuditLogService) downloadAuditLogChunk(ctx context.Context, query Audit
 }
 
 func (r *AuditLogService) downloadAuditLogChunkOnce(ctx context.Context, query AuditLogExportChunkParams, opts []option.RequestOption) ([]byte, http.Header, error) {
-	requestOpts := make([]option.RequestOption, 0, len(opts)+1)
-	requestOpts = append(requestOpts, opts...)
-	requestOpts = append(requestOpts, option.WithMaxRetries(0))
-	res, err := r.ExportChunk(ctx, query, requestOpts...)
+	res, err := r.ExportChunk(ctx, query, opts...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -160,25 +177,29 @@ func (r *AuditLogService) downloadAuditLogChunkOnce(ctx context.Context, query A
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		return nil, nil, fmt.Errorf("read audit log chunk: %w", err)
+		return nil, nil, &auditLogTransferError{err: fmt.Errorf("read audit log chunk: %w", err)}
 	}
 	want := res.Header.Get("X-Content-Sha256")
 	if want == "" {
-		return nil, nil, fmt.Errorf("response missing X-Content-Sha256 header")
+		return nil, nil, &auditLogTransferError{err: fmt.Errorf("response missing X-Content-Sha256 header")}
 	}
 	sum := sha256.Sum256(body)
 	if got := hex.EncodeToString(sum[:]); got != want {
-		return nil, nil, fmt.Errorf("audit log chunk checksum mismatch (got %s, want %s)", got, want)
+		return nil, nil, &auditLogTransferError{err: fmt.Errorf("audit log chunk checksum mismatch (got %s, want %s)", got, want)}
 	}
 	return body, res.Header, nil
 }
 
-func retryableAuditLogDownloadError(err error) bool {
-	var apiErr *Error
-	if errors.As(err, &apiErr) {
-		return apiErr.StatusCode == http.StatusTooManyRequests || apiErr.StatusCode >= 500
-	}
-	return !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded)
+type auditLogTransferError struct {
+	err error
+}
+
+func (e *auditLogTransferError) Error() string {
+	return e.err.Error()
+}
+
+func (e *auditLogTransferError) Unwrap() error {
+	return e.err
 }
 
 func parseAuditLogDownloadHeaders(header http.Header, currentCursor string) (int64, string, bool, error) {

--- a/auditlog_download_test.go
+++ b/auditlog_download_test.go
@@ -77,10 +77,6 @@ func TestAuditLogDownloadWritesVerifiedChunks(t *testing.T) {
 }
 
 func TestAuditLogDownloadRetriesChecksumMismatch(t *testing.T) {
-	oldDelay := auditLogDownloadRetryBaseDelay
-	auditLogDownloadRetryBaseDelay = 0
-	t.Cleanup(func() { auditLogDownloadRetryBaseDelay = oldDelay })
-
 	attempts := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		attempts++
@@ -126,15 +122,12 @@ func TestAuditLogDownloadRejectsInvalidCursorBeforeWriting(t *testing.T) {
 	}
 }
 
-func TestAuditLogDownloadOwnsHTTPRetries(t *testing.T) {
-	oldDelay := auditLogDownloadRetryBaseDelay
-	auditLogDownloadRetryBaseDelay = 0
-	t.Cleanup(func() { auditLogDownloadRetryBaseDelay = oldDelay })
-
+func TestAuditLogDownloadRespectsHTTPRetryOptions(t *testing.T) {
 	attempts := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		attempts++
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Should-Retry", "false")
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte(`{"message":"temporary failure"}`))
 	}))
@@ -150,16 +143,65 @@ func TestAuditLogDownloadOwnsHTTPRetries(t *testing.T) {
 	if err == nil {
 		t.Fatal("Download() error = nil")
 	}
-	if attempts != auditLogDownloadAttempts {
-		t.Fatalf("attempts = %d, want %d", attempts, auditLogDownloadAttempts)
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+}
+
+func TestAuditLogDownloadRespectsTransferRetryOption(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.Header().Set("X-Content-Sha256", "bad")
+		w.Header().Set("X-Has-More", "false")
+		w.Header().Set("X-Row-Count", "1")
+		_, _ = w.Write([]byte("chunk"))
+	}))
+	defer server.Close()
+
+	client := NewClient(option.WithBaseURL(server.URL), option.WithAPIKey("test"))
+	_, err := client.AuditLogs.Download(
+		context.Background(),
+		auditLogDownloadParams(),
+		&bytes.Buffer{},
+		WithAuditLogDownloadMaxTransferRetries(0),
+	)
+	if err == nil {
+		t.Fatal("Download() error = nil")
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+}
+
+func TestAuditLogDownloadRejectsCursorCycle(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts == 1 {
+			auditLogDownloadResponse(w, "first", "a", 1, true)
+			return
+		}
+		if attempts == 2 {
+			auditLogDownloadResponse(w, "second", "b", 1, true)
+			return
+		}
+		auditLogDownloadResponse(w, "duplicate", "a", 1, true)
+	}))
+	defer server.Close()
+
+	client := NewClient(option.WithBaseURL(server.URL), option.WithAPIKey("test"))
+	var dst bytes.Buffer
+	_, err := client.AuditLogs.Download(context.Background(), auditLogDownloadParams(), &dst)
+	if err == nil || err.Error() != "response repeated X-Next-Cursor header" {
+		t.Fatalf("Download() error = %v", err)
+	}
+	if got, want := dst.String(), "firstsecond"; got != want {
+		t.Fatalf("download body = %q, want %q", got, want)
 	}
 }
 
 func TestAuditLogDownloadDoesNotRetryClientErrors(t *testing.T) {
-	oldDelay := auditLogDownloadRetryBaseDelay
-	auditLogDownloadRetryBaseDelay = 0
-	t.Cleanup(func() { auditLogDownloadRetryBaseDelay = oldDelay })
-
 	attempts := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		attempts++

--- a/auditlog_download_test.go
+++ b/auditlog_download_test.go
@@ -174,6 +174,59 @@ func TestAuditLogDownloadRespectsTransferRetryOption(t *testing.T) {
 	}
 }
 
+func TestAuditLogDownloadRetryDelayCapsBeforeOverflow(t *testing.T) {
+	for _, attempt := range []int{4, 35, 100} {
+		if got := auditLogDownloadRetryDelay(attempt); got != auditLogDownloadMaxRetryDelay {
+			t.Fatalf("auditLogDownloadRetryDelay(%d) = %s, want %s", attempt, got, auditLogDownloadMaxRetryDelay)
+		}
+	}
+}
+
+func TestParseAuditLogDownloadHeadersRejectsMalformedValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		header http.Header
+	}{
+		{
+			name: "non-canonical has more",
+			header: http.Header{
+				"X-Has-More":  []string{"TRUE"},
+				"X-Row-Count": []string{"1"},
+			},
+		},
+		{
+			name: "empty row count",
+			header: http.Header{
+				"X-Has-More":  []string{"false"},
+				"X-Row-Count": []string{""},
+			},
+		},
+		{
+			name: "non-decimal row count",
+			header: http.Header{
+				"X-Has-More":  []string{"false"},
+				"X-Row-Count": []string{"1.0"},
+			},
+		},
+		{
+			name: "row count above chunk limit",
+			header: http.Header{
+				"X-Has-More":  []string{"false"},
+				"X-Row-Count": []string{"50001"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, _, err := parseAuditLogDownloadHeaders(test.header, "")
+			if err == nil {
+				t.Fatal("parseAuditLogDownloadHeaders() error = nil")
+			}
+		})
+	}
+}
+
 func TestAuditLogDownloadRejectsCursorCycle(t *testing.T) {
 	attempts := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/auditlog_download_test.go
+++ b/auditlog_download_test.go
@@ -1,0 +1,204 @@
+package kernel
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/kernel/kernel-go-sdk/option"
+)
+
+func auditLogDownloadResponse(w http.ResponseWriter, body, nextCursor string, rows int, hasMore bool) {
+	sum := sha256.Sum256([]byte(body))
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("X-Content-Sha256", hex.EncodeToString(sum[:]))
+	w.Header().Set("X-Has-More", strconv.FormatBool(hasMore))
+	w.Header().Set("X-Row-Count", strconv.Itoa(rows))
+	if nextCursor != "" {
+		w.Header().Set("X-Next-Cursor", nextCursor)
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(body))
+}
+
+func auditLogDownloadParams() AuditLogDownloadParams {
+	return AuditLogDownloadParams{
+		Start:  time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
+		End:    time.Date(2026, time.June, 2, 0, 0, 0, 0, time.UTC),
+		Format: AuditLogExportChunkParamsFormatJSONLGz,
+	}
+}
+
+func TestAuditLogDownloadWritesVerifiedChunks(t *testing.T) {
+	var cursors []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cursors = append(cursors, r.URL.Query().Get("cursor"))
+		if len(cursors) == 1 {
+			auditLogDownloadResponse(w, "first", "next", 2, true)
+			return
+		}
+		auditLogDownloadResponse(w, "second", "", 1, false)
+	}))
+	defer server.Close()
+
+	client := NewClient(option.WithBaseURL(server.URL), option.WithAPIKey("test"))
+	var dst bytes.Buffer
+	var progress []AuditLogDownloadProgress
+	result, err := client.AuditLogs.Download(
+		context.Background(),
+		auditLogDownloadParams(),
+		&dst,
+		WithAuditLogDownloadProgress(func(update AuditLogDownloadProgress) {
+			progress = append(progress, update)
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Download() error = %v", err)
+	}
+	if got, want := dst.String(), "firstsecond"; got != want {
+		t.Fatalf("download body = %q, want %q", got, want)
+	}
+	if len(cursors) != 2 || cursors[0] != "" || cursors[1] != "next" {
+		t.Fatalf("cursors = %#v, want [\"\" \"next\"]", cursors)
+	}
+	if result != (AuditLogDownloadResult{BytesWritten: 11, Chunks: 2, Rows: 3}) {
+		t.Fatalf("result = %#v", result)
+	}
+	if len(progress) != 2 || progress[1].AuditLogDownloadResult != result || progress[1].ChunkRows != 1 {
+		t.Fatalf("progress = %#v", progress)
+	}
+}
+
+func TestAuditLogDownloadRetriesChecksumMismatch(t *testing.T) {
+	oldDelay := auditLogDownloadRetryBaseDelay
+	auditLogDownloadRetryBaseDelay = 0
+	t.Cleanup(func() { auditLogDownloadRetryBaseDelay = oldDelay })
+
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts == 1 {
+			w.Header().Set("X-Content-Sha256", "bad")
+			w.Header().Set("X-Has-More", "false")
+			w.Header().Set("X-Row-Count", "1")
+			_, _ = w.Write([]byte("chunk"))
+			return
+		}
+		auditLogDownloadResponse(w, "chunk", "", 1, false)
+	}))
+	defer server.Close()
+
+	client := NewClient(option.WithBaseURL(server.URL), option.WithAPIKey("test"))
+	var dst bytes.Buffer
+	_, err := client.AuditLogs.Download(context.Background(), auditLogDownloadParams(), &dst)
+	if err != nil {
+		t.Fatalf("Download() error = %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+	if dst.String() != "chunk" {
+		t.Fatalf("download body = %q", dst.String())
+	}
+}
+
+func TestAuditLogDownloadRejectsInvalidCursorBeforeWriting(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auditLogDownloadResponse(w, "chunk", "", 1, true)
+	}))
+	defer server.Close()
+
+	client := NewClient(option.WithBaseURL(server.URL), option.WithAPIKey("test"))
+	var dst bytes.Buffer
+	_, err := client.AuditLogs.Download(context.Background(), auditLogDownloadParams(), &dst)
+	if err == nil || err.Error() != "response has invalid X-Next-Cursor header" {
+		t.Fatalf("Download() error = %v", err)
+	}
+	if dst.Len() != 0 {
+		t.Fatalf("wrote %d bytes before cursor validation", dst.Len())
+	}
+}
+
+func TestAuditLogDownloadOwnsHTTPRetries(t *testing.T) {
+	oldDelay := auditLogDownloadRetryBaseDelay
+	auditLogDownloadRetryBaseDelay = 0
+	t.Cleanup(func() { auditLogDownloadRetryBaseDelay = oldDelay })
+
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"temporary failure"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(option.WithBaseURL(server.URL), option.WithAPIKey("test"))
+	_, err := client.AuditLogs.Download(
+		context.Background(),
+		auditLogDownloadParams(),
+		&bytes.Buffer{},
+		WithAuditLogDownloadRequestOptions(option.WithMaxRetries(5)),
+	)
+	if err == nil {
+		t.Fatal("Download() error = nil")
+	}
+	if attempts != auditLogDownloadAttempts {
+		t.Fatalf("attempts = %d, want %d", attempts, auditLogDownloadAttempts)
+	}
+}
+
+func TestAuditLogDownloadDoesNotRetryClientErrors(t *testing.T) {
+	oldDelay := auditLogDownloadRetryBaseDelay
+	auditLogDownloadRetryBaseDelay = 0
+	t.Cleanup(func() { auditLogDownloadRetryBaseDelay = oldDelay })
+
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message":"bad request"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(option.WithBaseURL(server.URL), option.WithAPIKey("test"))
+	_, err := client.AuditLogs.Download(context.Background(), auditLogDownloadParams(), &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("Download() error = nil")
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+}
+
+type failingAuditLogWriter struct{}
+
+func (failingAuditLogWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func TestAuditLogDownloadStopsOnDestinationError(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		auditLogDownloadResponse(w, "chunk", "next", 1, true)
+	}))
+	defer server.Close()
+
+	client := NewClient(option.WithBaseURL(server.URL), option.WithAPIKey("test"))
+	_, err := client.AuditLogs.Download(context.Background(), auditLogDownloadParams(), failingAuditLogWriter{})
+	if err == nil || err.Error() != "write audit log download: write failed" {
+		t.Fatalf("Download() error = %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+}

--- a/auditlog_download_test.go
+++ b/auditlog_download_test.go
@@ -30,16 +30,17 @@ func auditLogDownloadResponse(w http.ResponseWriter, body, nextCursor string, ro
 
 func auditLogDownloadParams() AuditLogDownloadParams {
 	return AuditLogDownloadParams{
-		Start:  time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
-		End:    time.Date(2026, time.June, 2, 0, 0, 0, 0, time.UTC),
-		Format: AuditLogExportChunkParamsFormatJSONLGz,
+		Start: time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
+		End:   time.Date(2026, time.June, 2, 0, 0, 0, 0, time.UTC),
 	}
 }
 
 func TestAuditLogDownloadWritesVerifiedChunks(t *testing.T) {
 	var cursors []string
+	var formatProvided []bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		cursors = append(cursors, r.URL.Query().Get("cursor"))
+		formatProvided = append(formatProvided, r.URL.Query().Has("format"))
 		if len(cursors) == 1 {
 			auditLogDownloadResponse(w, "first", "next", 2, true)
 			return
@@ -67,6 +68,9 @@ func TestAuditLogDownloadWritesVerifiedChunks(t *testing.T) {
 	}
 	if len(cursors) != 2 || cursors[0] != "" || cursors[1] != "next" {
 		t.Fatalf("cursors = %#v, want [\"\" \"next\"]", cursors)
+	}
+	if len(formatProvided) != 2 || formatProvided[0] || formatProvided[1] {
+		t.Fatalf("format provided = %#v, want omitted", formatProvided)
 	}
 	if result != (AuditLogDownloadResult{BytesWritten: 11, Chunks: 2, Rows: 3}) {
 		t.Fatalf("result = %#v", result)


### PR DESCRIPTION
## Summary

- add `AuditLogs.Download` for complete exports while retaining `ExportChunk` for low-level access
- use gzip-compressed JSON Lines for high-level downloads; raw format selection remains on `ExportChunk`
- verify checksums and reject missing, stalled, or cyclic cursor chains before writing each chunk
- preserve standard SDK HTTP retry behavior and make transfer retries configurable
- report download totals and optional progress, with partial-output behavior documented

## Testing

- `go test ./...`
- `go vet ./...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New client-side SDK helper with no changes to existing APIs; risk is limited to callers adopting `Download` and handling documented partial-output behavior on failure.
> 
> **Overview**
> Adds **`AuditLogs.Download`**, a high-level helper that streams a full gzip JSON Lines audit export to an `io.Writer` by repeatedly calling the existing **`ExportChunk`** API with cursor pagination.
> 
> Each chunk is validated before write: **`X-Content-Sha256`** must match the body, pagination headers (`X-Has-More`, `X-Row-Count`, `X-Next-Cursor`) are strictly checked (including rejecting stalled or cyclic cursors), and invalid pagination fails **before** bytes are written. Transient read/checksum failures retry with capped exponential backoff via **`WithAuditLogDownloadMaxTransferRetries`**, while HTTP retries stay on the standard SDK request options (**`WithAuditLogDownloadRequestOptions`**). Optional **`WithAuditLogDownloadProgress`** reports cumulative bytes/chunks/rows after each verified chunk; docs note that errors can leave partial output on `dst`.
> 
> Tests cover multi-chunk success, checksum retry, cursor/header rejection, cursor cycles, HTTP vs transfer retry limits, and write failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65ed54ae30f382d8f9c01af69f37cfa48164096c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
