### PR TITLE
fix(ci): unbreak Update CLI Coverage workflow, switch cursor-agent → Claude Code

### DIFF
--- a/.github/workflows/update-cli-coverage.yml
+++ b/.github/workflows/update-cli-coverage.yml
@@ -72,17 +72,10 @@ jobs:
           # For manual dispatch with a specific PR, checkout the merge commit
           ref: ${{ steps.pr-info.outputs.merge_sha || github.sha }}
 
-      - name: Install Cursor CLI
+      - name: Install Claude Code CLI
         run: |
-          curl https://cursor.com/install -fsS | bash
-          echo "$HOME/.cursor/bin" >> $GITHUB_PATH
-
-      - name: Enable Cursor Max Mode
-        run: |
-          CFG_DIR="$HOME/.cursor"
-          mkdir -p "$CFG_DIR"
-          echo '{"maxMode": true}' > "$CFG_DIR/cli-config.json"
-          echo "CURSOR_CONFIG_DIR=$CFG_DIR" >> "$GITHUB_ENV"
+          curl -fsSL https://claude.ai/install.sh | bash
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Configure git identity
         run: |
@@ -110,7 +103,7 @@ jobs:
           if git fetch origin cli-coverage-update 2>/dev/null; then
             echo "Branch cli-coverage-update exists, checking it out..."
             git checkout cli-coverage-update
-            git merge origin/main -m "Merge main into cli-coverage-update" --no-edit || true
+            git merge -X theirs origin/main -m "Merge main into cli-coverage-update" --no-edit || true
           else
             echo "Branch cli-coverage-update does not exist, will create from main"
           fi
@@ -145,7 +138,13 @@ jobs:
         id: sdk-diff
         run: |
           # Extract the SDK version currently used by the CLI
-          OLD_SDK_VERSION=$(grep 'kernel/kernel-go-sdk' /tmp/kernel-cli/go.mod | awk '{print $2}')
+          # Prefer go list (parses go.mod properly); fall back to grep, taking the
+          # first non-conflict-marker match so a merge conflict can't yield a
+          # multi-line value that breaks $GITHUB_OUTPUT.
+          OLD_SDK_VERSION=$(cd /tmp/kernel-cli && go list -m github.com/kernel/kernel-go-sdk 2>/dev/null | awk '{print $2}')
+          if [ -z "$OLD_SDK_VERSION" ]; then
+            OLD_SDK_VERSION=$(grep 'kernel/kernel-go-sdk' /tmp/kernel-cli/go.mod | grep -v '^[<>=]' | head -1 | awk '{print $2}')
+          fi
           echo "CLI currently uses SDK version: $OLD_SDK_VERSION"
           echo "old_version=$OLD_SDK_VERSION" >> $GITHUB_OUTPUT
 
@@ -167,12 +166,12 @@ jobs:
 
       - name: Update CLI coverage
         env:
-          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           KERNEL_API_KEY: ${{ secrets.KERNEL_API_KEY }}
           BRANCH_PREFIX: cli-coverage-update
         run: |
-          cursor-agent -p "You are a CLI updater that implements missing CLI commands based on SDK updates.
+          claude -p "You are a CLI updater that implements missing CLI commands based on SDK updates.
 
           The GitHub CLI is available as \`gh\` and authenticated via GH_TOKEN. Git is available. You have write access to the CLI repository (kernel/cli).
 
@@ -418,4 +417,4 @@ jobs:
           - Streaming methods may have different CLI implementations (e.g., follow flags)
           - Even if no coverage gaps are found, still create a PR for the SDK version bump
           - Ensure code compiles before pushing
-          " --model ${{ vars.CURSOR_PREFERRED_MODEL }} --force --output-format=text
+          " --model ${{ vars.CLAUDE_CODE_PREFERRED_MODEL }} --dangerously-skip-permissions --output-format text --verbose


### PR DESCRIPTION
## Problem

The **Update CLI Coverage** workflow has failed on every push to main since **2026-04-21** (~40 consecutive failures). Root cause, reproduced locally:

1. The workflow merges `origin/main` into the long-lived `cli-coverage-update` branch in kernel/cli. That branch is pinned to SDK v0.50.0 while main is at v0.79.0 → **merge conflict in go.mod/go.sum**.
2. `|| true` swallows the conflict, leaving conflict markers in go.mod.
3. `grep 'kernel/kernel-go-sdk' go.mod` then returns **two versions**, and the multi-line value breaks the `$GITHUB_OUTPUT` write:
   ```
   ##[error]Unable to process file command 'output' successfully.
   ##[error]Invalid format 'v0.79.0'
   ```
4. The run dies before the agent ever starts. (Also note: kernel/cli#140, the branch's evergreen PR, has been untouched since March 30.)

## Fix

- **Merge with `-X theirs`** so go.mod/go.sum conflicts auto-resolve to main's version.
- **Harden version extraction**: use `go list -m github.com/kernel/kernel-go-sdk` with a grep fallback that skips conflict-marker lines and takes the first match — a multi-line value can never reach `$GITHUB_OUTPUT` again.
- **Switch cursor-agent → Claude Code CLI**, matching the pattern in kernel/kernel-browser:
  - Install via `https://claude.ai/install.sh`
  - `ANTHROPIC_API_KEY` org secret + `CLAUDE_CODE_PREFERRED_MODEL` org var (both already exist with ALL-repo visibility)
  - `claude -p ... --dangerously-skip-permissions --output-format text --verbose`

## Follow-ups (not in this PR)

- Decide what to do with the stale kernel/cli#140 (close it and let the next run regenerate from main is probably cleanest).
- Optionally trigger a manual `workflow_dispatch` run after merge to verify end-to-end.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes with no application runtime impact; the agent step uses existing org secrets and follows patterns used elsewhere in the org.
> 
> **Overview**
> **Repairs the Update CLI Coverage workflow** so it can run again after repeated failures from unresolved `go.mod` merge conflicts on the long-lived `cli-coverage-update` branch.
> 
> When syncing that branch with `origin/main`, merges now use **`-X theirs`** so `go.mod`/`go.sum` conflicts favor main’s versions instead of leaving conflict markers. **SDK version detection** prefers `go list -m github.com/kernel/kernel-go-sdk`, with a grep fallback that skips conflict-marker lines and takes a single match so `$GITHUB_OUTPUT` cannot get a multi-line value.
> 
> The automation agent is **switched from Cursor to Claude Code**: install via `claude.ai/install.sh`, `ANTHROPIC_API_KEY` and `CLAUDE_CODE_PREFERRED_MODEL`, and `claude -p` with `--dangerously-skip-permissions` instead of `cursor-agent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1f93c90d94cbdab72bd64063c2c7b316b00c6ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->