### PR TITLE
test: prevent stream cancellation cleanup hangs

### DIFF
--- a/browser_routing_test.go
+++ b/browser_routing_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -138,8 +139,11 @@ func TestBrowserRoutingRewritesTelemetryStreamToVM(t *testing.T) {
 func TestBrowserRoutingTelemetryStreamPreservesContextCancellation(t *testing.T) {
 	t.Setenv(browserRoutingSubresourcesEnv, "telemetry/stream")
 
+	handlerDone := make(chan struct{})
 	requestCanceled := make(chan struct{})
 	streamPath := make(chan string, 1)
+	var requestCanceledOnce sync.Once
+	var streamPathOnce sync.Once
 	var srv *httptest.Server
 	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/browsers" {
@@ -152,14 +156,20 @@ func TestBrowserRoutingTelemetryStreamPreservesContextCancellation(t *testing.T)
 			return
 		}
 
-		streamPath <- r.URL.RequestURI()
+		streamPathOnce.Do(func() { streamPath <- r.URL.RequestURI() })
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
 		w.(http.Flusher).Flush()
-		<-r.Context().Done()
-		close(requestCanceled)
+		select {
+		case <-r.Context().Done():
+			requestCanceledOnce.Do(func() { close(requestCanceled) })
+		case <-handlerDone:
+		}
 	}))
-	defer srv.Close()
+	t.Cleanup(func() {
+		close(handlerDone)
+		srv.Close()
+	})
 
 	client := NewClient(
 		option.WithBaseURL(srv.URL),


### PR DESCRIPTION
## Summary

- give the telemetry handler a cleanup exit path so a cancellation regression reports its assertion instead of hanging in `httptest.Server.Close`
- guard test channels against duplicate handler entries

Follow-up to #155.

## Tests

- `./scripts/test`
- `./scripts/lint`
- `go test -race ./...`
- intentional lost-context mutation fails cleanly at the one-second assertion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to mock handler lifecycle and cleanup; no production routing or SDK behavior is modified.
> 
> **Overview**
> **Fixes a hang in** `TestBrowserRoutingTelemetryStreamPreservesContextCancellation` **when** `httptest.Server` **shuts down before the mock SSE handler unblocks.**
> 
> The mock telemetry handler now waits on either request context cancellation or a `handlerDone` signal, and `t.Cleanup` closes `handlerDone` before closing the server so teardown does not block indefinitely. `sync.Once` guards `streamPath` and `requestCanceled` so duplicate handler invocations cannot panic or double-close channels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8607d7e44c7e4e3cff1a75cbcc5de3fe5bfaf9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->