### PR TITLE
feat: route process calls directly to browser VMs

### DIFF
--- a/browser_routing.go
+++ b/browser_routing.go
@@ -86,7 +86,7 @@ func browserRoutingSubresourcesFromEnv() []string {
 		// Path prefixes eligible for direct-to-VM routing. "telemetry/stream" is
 		// the live SSE endpoint (served by the VM); "telemetry/events" is a
 		// historical read served by the control plane (S2) and must NOT be here.
-		return []string{"curl", "telemetry/stream", "computer", "playwright"}
+		return []string{"curl", "telemetry/stream", "computer", "playwright", "process"}
 	}
 	if strings.TrimSpace(raw) == "" {
 		return []string{}

--- a/browser_routing_test.go
+++ b/browser_routing_test.go
@@ -266,8 +266,8 @@ func TestBrowserRoutingSubresourcesFromEnvDefaults(t *testing.T) {
 		}
 		_ = os.Setenv(browserRoutingSubresourcesEnv, original)
 	})
-	if got := browserRoutingSubresourcesFromEnv(); len(got) != 4 || got[0] != "curl" || got[1] != "telemetry/stream" || got[2] != "computer" || got[3] != "playwright" {
-		t.Fatalf("expected default subresources [curl telemetry/stream computer playwright], got %#v", got)
+	if got := browserRoutingSubresourcesFromEnv(); len(got) != 5 || got[0] != "curl" || got[1] != "telemetry/stream" || got[2] != "computer" || got[3] != "playwright" || got[4] != "process" {
+		t.Fatalf("expected default subresources [curl telemetry/stream computer playwright process], got %#v", got)
 	}
 
 	t.Setenv(browserRoutingSubresourcesEnv, "")
@@ -288,7 +288,7 @@ func TestBrowserRoutingSubresourcesFromEnvDefaults(t *testing.T) {
 	}
 }
 
-func TestBrowserRoutingDefaultsComputerAndPlaywrightToVM(t *testing.T) {
+func TestBrowserRoutingDefaultsRouteToVM(t *testing.T) {
 	original, ok := os.LookupEnv(browserRoutingSubresourcesEnv)
 	if err := os.Unsetenv(browserRoutingSubresourcesEnv); err != nil {
 		t.Fatal(err)
@@ -324,6 +324,14 @@ func TestBrowserRoutingDefaultsComputerAndPlaywrightToVM(t *testing.T) {
 			w.Header().Set("Content-Type", "image/png")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte{0x89, 0x50, 0x4e, 0x47})
+		case "/browser/kernel/process/exec":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"duration_ms": 1,
+				"exit_code":   0,
+				"stderr_b64":  "",
+				"stdout_b64":  "",
+			})
 		default:
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{"success": true})
@@ -350,9 +358,12 @@ func TestBrowserRoutingDefaultsComputerAndPlaywrightToVM(t *testing.T) {
 	if _, err := client.Browsers.Playwright.Execute(context.Background(), "sess-1", BrowserPlaywrightExecuteParams{Code: "return 1"}); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := client.Browsers.Process.Exec(context.Background(), "sess-1", BrowserProcessExecParams{Command: "echo"}); err != nil {
+		t.Fatal(err)
+	}
 
-	if len(calls) != 3 {
-		t.Fatalf("expected 3 calls, got %d %#v", len(calls), calls)
+	if len(calls) != 4 {
+		t.Fatalf("expected 4 calls, got %d %#v", len(calls), calls)
 	}
 	if calls[1].Path != "/browser/kernel/computer/screenshot?jwt=token-abc" {
 		t.Fatalf("expected direct VM screenshot path, got %q", calls[1].Path)
@@ -366,9 +377,15 @@ func TestBrowserRoutingDefaultsComputerAndPlaywrightToVM(t *testing.T) {
 	if calls[2].Auth != "" {
 		t.Fatalf("expected authorization header removed, got %q", calls[2].Auth)
 	}
+	if calls[3].Path != "/browser/kernel/process/exec?jwt=token-abc" {
+		t.Fatalf("expected direct VM process path, got %q", calls[3].Path)
+	}
+	if calls[3].Auth != "" {
+		t.Fatalf("expected authorization header removed, got %q", calls[3].Auth)
+	}
 }
 
-func TestBrowserRoutingDefaultsKeepProcessFsAndTelemetryEventsOnAPI(t *testing.T) {
+func TestBrowserRoutingDefaultsKeepFsAndTelemetryEventsOnAPI(t *testing.T) {
 	original, ok := os.LookupEnv(browserRoutingSubresourcesEnv)
 	if err := os.Unsetenv(browserRoutingSubresourcesEnv); err != nil {
 		t.Fatal(err)
@@ -421,9 +438,6 @@ func TestBrowserRoutingDefaultsKeepProcessFsAndTelemetryEventsOnAPI(t *testing.T
 	if _, err := client.Browsers.New(context.Background(), BrowserNewParams{}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := client.Browsers.Process.Exec(context.Background(), "sess-1", BrowserProcessExecParams{Command: "echo"}); err != nil {
-		t.Fatal(err)
-	}
 	fsResp, err := client.Browsers.Fs.ReadFile(context.Background(), "sess-1", BrowserFReadFileParams{Path: "/tmp/x"})
 	if err != nil {
 		t.Fatal(err)
@@ -437,7 +451,6 @@ func TestBrowserRoutingDefaultsKeepProcessFsAndTelemetryEventsOnAPI(t *testing.T
 
 	want := []string{
 		"/browsers",
-		"/browsers/sess-1/process/exec",
 		"/browsers/sess-1/fs/read_file",
 		"/browsers/sess-1/telemetry/events",
 	}

--- a/lib/browserrouting/route_cache_test.go
+++ b/lib/browserrouting/route_cache_test.go
@@ -69,7 +69,8 @@ func TestDirectVMRoutingMiddlewareAllowlistMatching(t *testing.T) {
 		{"curl proxy -> VM", "/browsers/sess-1/curl/raw", true},
 		{"computer screenshot -> VM", "/browsers/sess-1/computer/screenshot", true},
 		{"playwright execute -> VM", "/browsers/sess-1/playwright/execute", true},
-		{"process exec -> control plane", "/browsers/sess-1/process/exec", false},
+		{"process exec -> VM", "/browsers/sess-1/process/exec", true},
+		{"process stdout stream -> VM", "/browsers/sess-1/process/proc-1/stdout/stream", true},
 		{"non-allowlisted subresource -> control plane", "/browsers/sess-1/fs/read", false},
 	}
 
@@ -81,7 +82,7 @@ func TestDirectVMRoutingMiddlewareAllowlistMatching(t *testing.T) {
 				BaseURL:   "https://browser.example/browser/kernel",
 				JWT:       "jwt-123",
 			})
-			middleware := DirectVMRoutingMiddleware(cache, []string{"curl", "telemetry/stream", "computer", "playwright"})
+			middleware := DirectVMRoutingMiddleware(cache, []string{"curl", "telemetry/stream", "computer", "playwright", "process"})
 
 			reqURL, err := url.Parse("https://api.example" + tc.path)
 			if err != nil {


### PR DESCRIPTION
## summary

- add `process` to the default direct-to-VM browser routing allowlist
- cover process exec, spawn, kill, resize, status, stdin, and stdout streaming through the existing prefix matcher
- keep `fs/*` and `telemetry/events` on the control plane and preserve the environment override/kill switch

## testing

- `go test ./...`
- live browser validation: exec, spawn, and stdout streaming routed through `/browser/kernel/process/...` and returned the expected output

## release

This PR targets `next`. After merge, release-please opens or updates the versioned `next → main` release PR. Merging that release PR publishes the Go module tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default routing for process endpoints changes from control plane to VM, but behavior matches other VM-backed subresources and remains overridable via env.
> 
> **Overview**
> Adds **`process`** to the default direct-to-VM browser routing allowlist in `browserRoutingSubresourcesFromEnv`, so process APIs (e.g. **exec**, spawn, streams under the `process` prefix) are rewritten to the session VM like curl, computer, playwright, and telemetry/stream.
> 
> **`fs/*`** and **`telemetry/events`** stay on the control plane; the **`KERNEL_BROWSER_ROUTING_SUBRESOURCES`** env override and empty-string kill switch are unchanged.
> 
> Tests are updated to expect five default subresources, process exec on `/browser/kernel/process/...` with JWT and no API key header, and allowlist cases for process exec and stdout streaming to the VM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71c0e509a24e4cc4db3ad0d2af61a2536981e312. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->